### PR TITLE
added llama3 uts option

### DIFF
--- a/Assets/Scripts/Core/UniversalTextScanner/Llama3Client.cs
+++ b/Assets/Scripts/Core/UniversalTextScanner/Llama3Client.cs
@@ -1,0 +1,53 @@
+using System.Net.Http;
+using System.Text;
+using UnityEngine;
+
+namespace UniversalText.Core
+{
+    /// 
+    /// Handles communication with the self-hosted Llama 3 instance
+    /// 
+    public class Llama3Client
+    {
+        private readonly string _baseUrl;
+
+        // Constructor: Initializes the base URL for the Llama 3 instance
+        public Llama3Client(string baseUrl)
+        {
+            _baseUrl = baseUrl;
+        }
+
+        /// 
+        /// Sends the raw RTR to Llama 3 and retrieves the enhanced version
+        /// 
+        public async System.Threading.Tasks.Task<string> GetEnhancedDescriptionAsync(string rawRtr)
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                // Formulate the request payload
+                var requestData = new
+                {
+                    prompt = $"Make this description more natural and coherent: {rawRtr}"
+                };
+
+                // Convert the request data to JSON
+                string json = JsonUtility.ToJson(requestData);
+                StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                // Send POST request to Llama 3 endpoint
+                HttpResponseMessage response = await client.PostAsync($"{_baseUrl}/generate", content);
+                if (response.IsSuccessStatusCode)
+                {
+                    // Return the enhanced description
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    return responseBody;
+                }
+                else
+                {
+                    Debug.LogError($"Llama 3 request failed: {response.StatusCode}");
+                    return rawRtr;  // Return raw RTR if Llama 3 fails
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/UniversalTextScanner/UniversalTextScanner.cs
+++ b/Assets/Scripts/Core/UniversalTextScanner/UniversalTextScanner.cs
@@ -17,6 +17,16 @@ namespace UniversalText.Core
 
         private List<ISearchPoint> _searchPoints = new List<ISearchPoint>();
 
+        // Base URL for Llama 3 instance 
+        private readonly string _llama3BaseUrl = "http://localhost:8000";
+        private Llama3Client _llama3Client;
+
+        // Initialize the Llama3Client
+        private UniversalTextScanner()
+        {
+            _llama3Client = new Llama3Client(_llama3BaseUrl);
+        }
+
         /// <summary>
         /// Generates RTR by aggregating all search points
         /// </summary>
@@ -53,6 +63,19 @@ namespace UniversalText.Core
                 rtr = rtr.Remove(rtr.Length - 1);
             }
             return rtr;
+        }
+
+         /// 
+        /// Generates an enhanced RTR by sending raw RTR to Llama 3
+        /// 
+        public async Task<string> GenerateEnhancedAsync()
+        {
+            // Get the raw RTR output
+            string rawRtr = Generate();
+
+            // Use Llama 3 to enhance the description
+            string enhancedRtr = await _llama3Client.GetEnhancedDescriptionAsync(rawRtr);
+            return enhancedRtr;
         }
 
         /// <summary>


### PR DESCRIPTION
Using the current self-hosted Llama 3 implementation, write a script that uses Llama 3 to clean up the output of the UniversalTextScanner. 

This will be an optional feature for developers, as the Llama 3 generation is not nearly as performant as simply using the UTS’ raw output, but may produce much better results.

The implementation will involve fetching the raw RTR from the UTS’ Generate() method, and passing it to Llama 3 using some specific prompt that produces a more natural description of the user’s environment and interactions.

completed this task mentioned on the kanban board